### PR TITLE
README: Fix broken link to `govuk-puppet` repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Business Link Assets
 ====================
 
 This repository contains assets from businesslink.gov.uk which continue to be
-served via [Bouncer's nginx configuration](https://github.gds/gds/puppet/blob/master/modules/govuk/manifests/apps/bouncer.pp).
+served via [Bouncer's nginx configuration](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/bouncer.pp).
 
 Changes to this repository are released by deploying [Bouncer](https://github.com/alphagov/bouncer). It is independent of the Bouncer version, so simply redeploying the current version of Bouncer is
 enough.


### PR DESCRIPTION
- I remembered that this was a thing after introducing someone to the Transition Architecture doc. After following the trail of breadcrumbs, I found a broken link.